### PR TITLE
9 use parsimony scores

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "gctree"]
 	path = gctree
 	url = git@github.com:matsengrp/gctree.git
+	branch = wd-disambiguation-script

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "spr_neighbors"]
 	path = spr_neighbors
 	url = https://github.com/cwhidden/spr_neighbors.git
+[submodule "gctree"]
+	path = gctree
+	url = git@github.com:matsengrp/gctree.git

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ To run the analysis with multiple initial trees, write the trees to nni-analysis
     ./process-golden-for-nni-exploration.sh
     ./construct-nni-walk.sh
     ./analyze-nni-walk.sh
-
+To use parsimony scores instead of likelihood, call `./construct-nni-walk.sh --use_parsimony` in the above code. 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,7 +9,7 @@ realpath_osx() {
 }
 
 # Install all scripts with the `wtch` prefix into the conda environment.
-for script in scripts/wtch-* spr_neighbors/spr_neighbors;
+for script in scripts/wtch-* spr_neighbors/spr_neighbors gctree/scripts/parsimony.py;
 do
     test -e $CONDA_PREFIX/bin/$(basename $script) || ln -s $(realpath_osx $script) $CONDA_PREFIX/bin/
 done

--- a/scripts/wtch-investigate-nni-walk.py
+++ b/scripts/wtch-investigate-nni-walk.py
@@ -91,6 +91,9 @@ def nni_results_df_of(nni_rep_path, credible_rep_path, pp_rep_path, pp_values_pa
     nni_results_df["cred_total"] = nni_results_df["is_cred"].cumsum()
     nni_results_df["cred_frac"] = nni_results_df["cred_total"] / len(cred_set_reps)
     nni_results_df["bigger_sdag"] = sdag_increased
+    nni_results_df["comps_current"] = nni_results_df["bigger_sdag"] * 12
+    nni_results_df["comps_current"].iloc[0] = 48
+    nni_results_df["comps_total"] = nni_results_df["comps_current"].cumsum()
     nni_results_df["sdag_iter"] = nni_results_df["bigger_sdag"].cumsum()
 
     return nni_results_df
@@ -143,42 +146,48 @@ def run(
     # to the specified out_path. Each plot consists of some number of lines, each line
     # using a dataset with an x_attribute, y_attribute, and line_label, and optionally
     # the last value of a specified attribute of the dataset.
-    keys = ["mcmc_acc", "nni_acc", "nni_vs_mcmc_cred", "nni_vs_mcmc_pp"]
+    keys = ["mcmc_acc", "nni_acc", "nni_vs_mcmc_cred", "nni_vs_mcmc_pp", "comp_cred"]
     x_label = {
         "mcmc_acc": "mcmc iterations",
         "nni_acc": "sdag iteration",
         "nni_vs_mcmc_cred": "sdag iteration -- mcmc support",
         "nni_vs_mcmc_pp": "sdag iteration -- mcmc support",
+        "comp_cred": "approximate likelihood calculations",
     }
     y_label = {
         "mcmc_acc": None,
         "nni_acc": None,
         "nni_vs_mcmc_cred": "ratio of credible set",
         "nni_vs_mcmc_pp": "cumulative posterior probability",
+        "comp_cred": "ratio of credible set",
     }
     x_attr = {
         "mcmc_acc": ("mcmc_iters", "mcmc_iters"),
         "nni_acc": ("sdag_iter", "sdag_iter"),
         "nni_vs_mcmc_cred": ("sdag_iter", "support_size"),
         "nni_vs_mcmc_pp": ("sdag_iter", "support_size"),
+        "comp_cred": ("comps_total", "mcmc_iters"),
     }
     y_attr = {
         "mcmc_acc": ("total_pp", "credible_set_frac"),
         "nni_acc": ("total_pp", "cred_frac"),
         "nni_vs_mcmc_cred": ("cred_frac", "credible_set_frac"),
         "nni_vs_mcmc_pp": ("total_pp", "total_pp"),
+        "comp_cred": ("cred_frac", "credible_set_frac"),
     }
     data_set = {
         "mcmc_acc": (mcmc_pp_df, mcmc_pp_df),
         "nni_acc": (nni_pp_df, nni_pp_df),
         "nni_vs_mcmc_cred": (nni_cred_df, mcmc_cred_df),
         "nni_vs_mcmc_pp": (nni_pp_df, mcmc_pp_df),
+        "comp_cred": (nni_cred_df, mcmc_cred_df),
     }
     line_label = {
         "mcmc_acc": ("total pp", "fraction of credible set"),
         "nni_acc": ("total pp", "fraction of credible set"),
         "nni_vs_mcmc_cred": ("nni-walk", "mcmc"),
         "nni_vs_mcmc_pp": ("nni-walk", "mcmc"),
+        "comp_cred": ("nni-walk", "mcmc"),
     }
     extra_plot = {
         "mcmc_acc": (None, None),
@@ -191,12 +200,14 @@ def run(
             ("support_size", "sampled topologies", 0.8, 1.01),
             ("mcmc_iters", "mcmc iterations", 0.9, 0.95),
         ),
+        "comp_cred": (None, None),
     }
     out_path = {
         "mcmc_acc": "mcmc_accumulation.pdf",
         "nni_acc": "nni_accumulation.pdf",
         "nni_vs_mcmc_cred": "sdag_iter_vs_mcmc_credible.pdf",
         "nni_vs_mcmc_pp": "sdag_iter_vs_mcmc_total_pp.pdf",
+        "comp_cred": "computations_for_credible.pdf",
     }
 
     for key in keys:

--- a/scripts/wtch-nni-likelihood-walk.py
+++ b/scripts/wtch-nni-likelihood-walk.py
@@ -90,7 +90,7 @@ def parsimony_scores(nwk_list, fasta_map):
 
 def compute_parsimony_scores_from_files(nwk_path, fasta_path):
     """
-    Returns the parsomony scores for the newick strings in the file nwk_path using the
+    Returns the parsimony scores for the newick strings in the file nwk_path using the
     fasta file located at fasta_path.
     """
     nwk_list = read_nwk(nwk_path)

--- a/scripts/wtch-nni-likelihood-walk.py
+++ b/scripts/wtch-nni-likelihood-walk.py
@@ -5,6 +5,14 @@ import click
 import multiprocessing
 from sortedcontainers import SortedList
 from functools import partial
+import os
+import sys
+
+# This funny business with paths is needed because this file is intended to be called
+# from the command line by a sym link in $CONDA_PREFIX/bin, but naively python does not
+# know to check that directory for parsimony.py.
+sys.path.append(os.path.dirname(__file__))
+from parsimony import load_fasta, build_tree, sankoff_upward
 
 
 # A note on igraph and indexing:
@@ -28,7 +36,7 @@ def fast_line_count(file_path):
     wc -l.
     """
 
-    def _make_generator(reader):
+    def _make_gen(reader):
         while True:
             b = reader(2**16)
             if not b:
@@ -36,9 +44,7 @@ def fast_line_count(file_path):
             yield b
 
     with open(file_path, "rb") as the_file:
-        count = sum(
-            buffer.count(b"\n") for buffer in _make_generator(the_file.raw.read)
-        )
+        count = sum(buffer.count(b"\n") for buffer in _make_gen(the_file.raw.read))
     return count
 
 
@@ -59,47 +65,120 @@ def decode_int_as_sdag_nodes(the_int):
     return [j for j in range(the_int.bit_length()) if bit_string[j] == "1"]
 
 
-def load_trees(file_path, with_likelihoods=False):
-    """Loads in the tree data from file_path. The expected file format of file_path
-    is one tree per line, each line consists of i) a comma separated list of integers
-    of the subsplit dag node indices comprising the tree; ii) another comma followed by
-    nothing when with_likelihoods is False and the log-likelihood of the tree
-    when with_likelilihooods is True; and iii) the newline character \\n (even the final
-    line should have the newline character). The subsplit dag is not seen by any of
-    this code, so it is only assumed that the trees are all from a common sdag and the
-    node indices are correct.
+def build_and_score(nwk, fasta_map):
+    """Returns the parsimony score for the given newick string and custom fasta_map."""
+    return sankoff_upward(build_tree(nwk, fasta_map), gap_as_char=False)
+
+
+def parsimony_scores(nwk_list, fasta_map):
+    """
+    Returns the parsimony scores for the given list of newick strings and custom
+    fasta_map.
+    """
+    informative_sites = [
+        idx for idx, chars in enumerate(zip(*fasta_map.values())) if len(set(chars)) > 1
+    ]
+    newfasta = {
+        key: "".join(oldseq[idx] for idx in informative_sites)
+        for key, oldseq in fasta_map.items()
+    }
+    with multiprocessing.Pool(processes=16) as pool:
+        partial_build_and_score = partial(build_and_score, fasta_map=newfasta)
+        scores = pool.map(partial_build_and_score, nwk_list)
+    return scores
+
+
+def compute_parsimony_scores_from_files(nwk_path, fasta_path):
+    """
+    Returns the parsomony scores for the newick strings in the file nwk_path using the
+    fasta file located at fasta_path.
+    """
+    nwk_list = read_nwk(nwk_path)
+    fasta_map = load_fasta(fasta_path)
+    return parsimony_scores(nwk_list, fasta_map)
+
+
+def read_nwk(nwk_path):
+    """Returns the list of newick strings in the file nwk_path."""
+    tree_nwk_list = []
+    with open(nwk_path) as the_file:
+        for line in the_file:
+            tree_nwk_list.append(line.strip())
+    return tree_nwk_list
+
+
+def read_sdag_rep_trees(file_path, with_likelihoods=False):
+    """
+    Loads the tree data from file_path. The expected file format of file_path is one
+    tree per line, each line consists of i) a comma separated list of integers of the
+    subsplit dag node indices comprising the tree; ii) another comma; iii) nothing when
+    with_likelihoods=False and the log-likelihood of the tree when
+    with_likelilihooods=True; and iv) the newline character \\n (even the final line
+    should have the newline character).
+
+    Since the subsplit DAG is not seen by any of this code, it is assumed that the trees
+    are all from a common sDAG and the node indices are correct. Trees that are not in
+    this commond sDAG are identified by an invalid sDAG node index and are omitted from
+    the returned values.
 
     :return: A pair (T,L), where T is a python list of integers encoding each tree's
-        subsplit dag node representation and L is a numpy.array of each tree's
-        log-likelihood. When with_likelihoods is True, both T and L are sorted in
-        descending order according to log-likelihood. When with_likelihoods is False,
-        L is a vector of zeros.
+        subsplit DAG node representation (a single integer is used for a single tree),
+        and L is a numpy.array of each tree's log-likelihood. When
+        with_likelihoods=False, L is a vector of zeros. When with_likelihoods=True, both
+        T and L are sorted in descending order according to log-likelihood.
     :rtype: tuple
     """
     n_rows = fast_line_count(file_path)
-    # We use a python list of ints for tree_bit_list because Python does not have a
-    # maximum int size, but a numpy array of ints does.
+    # In bito, reps_and_likelihoods uses SIZE_MAX for unknown subsplits.
+    invalid_index = 2**64 - 1
     tree_bit_list = []
-    tree_log_likelihood_array = np.zeros(n_rows, dtype=float)
-    if not with_likelihoods:
-        # In bito, reps_and_likelihoods uses SIZE_MAX for unknown subsplits.
-        invalid_index = 2**64 - 1
-        with open(file_path, "rt") as the_file:
-            for line in the_file:
-                sdag_info = line[:-2].split(",")
-                sdag_info = [int(c) for c in sdag_info]
-                if invalid_index not in sdag_info:
-                    tree_bit_list.append(encode_sdag_nodes_as_int(sdag_info))
-    else:
-        with open(file_path, "rt") as the_file:
-            for j, line in enumerate(the_file):
-                sdag_info = line[:-1].split(",")
-                tree_bit_list.append(encode_sdag_nodes_as_int(map(int, sdag_info[:-1])))
-                tree_log_likelihood_array[j] = float(sdag_info[-1])
-        new_indices = tree_log_likelihood_array.argsort()[::-1]
+    tree_likelihood_array = np.zeros(n_rows, dtype=float)
+    with open(file_path, "rt") as the_file:
+        for j, line in enumerate(the_file):
+            tree_info = line.strip().split(",")
+            sdag_rep = [int(c) for c in tree_info[:-1]]
+            if invalid_index not in sdag_rep:
+                tree_bit_list.append(encode_sdag_nodes_as_int(sdag_rep))
+                if with_likelihoods:
+                    tree_likelihood_array[j] = float(tree_info[-1])
+    return tree_bit_list, tree_likelihood_array
+
+
+def process_trees(
+    file_path,
+    with_likelihoods=False,
+    use_parsimony=False,
+    nwk_path=None,
+    fasta_path=None,
+):
+    """
+    Loads the tree data from file_path (according to the method read_sdag_rep_trees).
+    If either with_likelihoods or use_parsimony is true, then both an integer list
+    encoding the trees and a numpy array of the statistic are returned and both are
+    sorted according to the statistic. When both with_likelihoods and use_parsimony are
+    false, only the list of integers encoding the trees is returned. Both nwk_path and
+    fasta_path are required when use_parsimony=True.
+
+    When using parsimony scores, the negative of the parsimony score is returned. This
+    is done so that the ordering is always descending (high likelihood is good, whereas
+    low parsimony is good).
+    """
+    if with_likelihoods and use_parsimony:
+        raise ValueError("process_trees cannot use both likelihood and parsimony")
+    if use_parsimony and (nwk_path is None or fasta_path is None):
+        raise ValueError("process_trees requires nwk_path and fasta_path for parsimony")
+
+    tree_bit_list, tree_scores = read_sdag_rep_trees(file_path, with_likelihoods)
+    if use_parsimony:
+        tree_scores = compute_parsimony_scores_from_files(nwk_path, fasta_path)
+        tree_scores = np.array([-p for p in tree_scores])
+    if with_likelihoods or use_parsimony:
+        new_indices = tree_scores.argsort()[::-1]
         tree_bit_list = [tree_bit_list[j] for j in new_indices]
-        tree_log_likelihood_array = tree_log_likelihood_array[new_indices]
-    return (tree_bit_list, tree_log_likelihood_array)
+        tree_scores = tree_scores[new_indices]
+        return tree_bit_list, tree_scores
+    else:
+        return tree_bit_list
 
 
 def are_nni_related(this_int, that_int):
@@ -166,37 +245,50 @@ def max_weight_neighbor_traversal(graph, weight_attribute, start_trees=[]):
 @click.option("--extra_trees_path", default=None)
 @click.option("--max_tree_count", default=0)
 @click.option("--max_tree_ratio", default=0.0)
+@click.option("--use_parsimony", default=False, is_flag=True)
+@click.option("--nwk_path", default=None)
+@click.option("--fasta_path", default=None)
 def find_likely_neighbors(
     sdag_rep_path,
     output_path,
     extra_trees_path=None,
     max_tree_count=0,
     max_tree_ratio=0.0,
+    use_parsimony=False,
+    nwk_path=None,
+    fasta_path=None,
 ):
     """
-    Determine a list of of trees that are nearest neighbor interchanges of each other
-    with high likelihood. The data for the trees are in sdag_rep_path and this file
-    must follow the format explained in the documentation for
-    load_trees(file_path, True). The optional parameter extra_trees_path specifies a
-    file of trees, following the format specified for load_trees(file_path, False),
-    with which to start the walk along with the highest likelihood tree.
-    The optional parameters max_tree_count and max_tree_ratio indicate to use only the
-    the first max_tree_count (max_tree_ratio, respectively) after sorting the trees
-    by log-likelihood. When max_tree_count and max_tree_ratio are both given, the more
-    restrictive condition is used.
+    Determine a list of trees that are nearest neighbor interchanges of each other with
+    high likelihood (or low parsimony score when use_parsimony=True). The trees and
+    scores are loaded according to the method process_trees. The optional parameter
+    extra_trees_path specifies a file of trees with which to start the list along with
+    the best scored tree. The optional parameters max_tree_count and max_tree_ratio
+    indicate to use only the first max_tree_count (max_tree_ratio, respectively) after
+    sorting the trees. When max_tree_count and max_tree_ratio are both given, the more
+    restrictive condition is used. The list of trees is determined by the method
+    max_weight_neighbor_traversal.
     """
-    tree_bits_list, log_likelihoods = load_trees(sdag_rep_path, True)
-    vertex_count = len(tree_bits_list)
+    weight_attr = "parsimony" if use_parsimony else "log_likelihood"
 
+    tree_bits_list, tree_scores = process_trees(
+        sdag_rep_path,
+        with_likelihoods=not use_parsimony,
+        use_parsimony=use_parsimony,
+        nwk_path=nwk_path,
+        fasta_path=fasta_path,
+    )
+
+    vertex_count = len(tree_bits_list)
     if max_tree_ratio > 0:
         vertex_count = min(vertex_count, int(np.floor(max_tree_ratio * vertex_count)))
     if max_tree_count > 0:
         vertex_count = min(vertex_count, max_tree_count)
     the_graph = igraph.Graph(vertex_count)
     the_graph.vs["encoded_sdag_representation"] = tree_bits_list[:vertex_count]
-    the_graph.vs["log_likelihood"] = log_likelihoods[:vertex_count]
+    the_graph.vs[weight_attr] = tree_scores[:vertex_count]
     tree_bits_list = None
-    log_likelihoods = None
+    tree_scores = None
 
     # For the cluster, 16 processes works well.
     with multiprocessing.Pool(processes=16) as pool:
@@ -208,17 +300,18 @@ def find_likely_neighbors(
         the_graph.add_edges(edge_list)
     # At this point, the graph is fully constructed.
 
-    extras = [] if extra_trees_path is None else load_trees(extra_trees_path, False)[0]
+    extras = [] if extra_trees_path is None else process_trees(extra_trees_path)
     extra_nodes = the_graph.vs.select(encoded_sdag_representation_in=extras)
+
     good_vertex_indices = max_weight_neighbor_traversal(
-        the_graph, "log_likelihood", extra_nodes
+        the_graph, weight_attr, extra_nodes
     )
 
     with open(output_path, "wt") as out_file:
         for vertex in the_graph.vs[good_vertex_indices]:
             sdag_rep = decode_int_as_sdag_nodes(vertex["encoded_sdag_representation"])
             out_file.write(
-                ",".join(map(str, sdag_rep)) + f",{vertex['log_likelihood']}" + "\n"
+                ",".join(map(str, sdag_rep)) + f",{vertex[weight_attr]}" + "\n"
             )
 
     return None

--- a/templates/construct-nni-walk.sh
+++ b/templates/construct-nni-walk.sh
@@ -1,15 +1,23 @@
 set -eu
 
 # This expects to run at watching-mb/nni-analysis/ds{{ds_number}}.
+
+# Call as ./construct-nni-walk.sh --use_parsimony to use parsimony scores instead of likelihoods.
 sdag_rep_path=ds{{ds_number}}.representations.csv
 nwk_path=ds{{ds_number}}.topologies.nwk
 fasta_path=ds{{ds_number}}.fasta
 output_path=ds{{ds_number}}.nni-walk.representations.csv
 extra_trees_path=ds{{ds_number}}.extra-trees.representations.csv
+
+extra_parameters=""
 if [[ -f $extra_trees_path && -s $extra_trees_path ]]
 then
-  wtch-nni-likelihood-walk.py $sdag_rep_path $nwk_path $fasta_path $output_path --extra_trees_path=$extra_trees_path --max_tree_ratio=0.01 $1
-else
-  wtch-nni-likelihood-walk.py $sdag_rep_path $nwk_path $fasta_path $output_path --max_tree_ratio=0.01 $1
+        extra_parameters=$extra_parameters"--extra_trees_path="$extra_trees_path" "
 fi
+if [[ $# != 0 ]]
+then
+        extra_parameters=$extra_parameters$1
+fi
+
+wtch-nni-likelihood-walk.py $sdag_rep_path $output_path --max_tree_ratio=0.01 --nwk_path=$nwk_path --fasta_path=$fasta_path $extra_parameters
 # Decrease the ratio for a faster run.

--- a/templates/construct-nni-walk.sh
+++ b/templates/construct-nni-walk.sh
@@ -2,12 +2,14 @@ set -eu
 
 # This expects to run at watching-mb/nni-analysis/ds{{ds_number}}.
 sdag_rep_path=ds{{ds_number}}.representations.csv
+nwk_path=ds{{ds_number}}.topologies.nwk
+fasta_path=ds{{ds_number}}.fasta
 output_path=ds{{ds_number}}.nni-walk.representations.csv
 extra_trees_path=ds{{ds_number}}.extra-trees.representations.csv
 if [[ -f $extra_trees_path && -s $extra_trees_path ]]
 then
-  wtch-nni-likelihood-walk.py $sdag_rep_path $output_path --extra_trees_path=$extra_trees_path --max_tree_ratio=0.01
+  wtch-nni-likelihood-walk.py $sdag_rep_path $nwk_path $fasta_path $output_path --extra_trees_path=$extra_trees_path --max_tree_ratio=0.01 $1
 else
-  wtch-nni-likelihood-walk.py $sdag_rep_path $output_path --max_tree_ratio=0.01
+  wtch-nni-likelihood-walk.py $sdag_rep_path $nwk_path $fasta_path $output_path --max_tree_ratio=0.01 $1
 fi
 # Decrease the ratio for a faster run.

--- a/templates/fancier.mb
+++ b/templates/fancier.mb
@@ -1,0 +1,11 @@
+execute {{nexus_alignment_path}};
+
+begin mrbayes;
+    set autoclose=yes nowarn=yes seed={{seed}} swapseed={{swapseed}};
+    lset nst=6 rates=gamma;
+    prset statefreqpr=fixed(equal) topologypr=uniform brlenspr={{brlenspr}};
+    mcmcp nruns=1 nchains={{nchains}} ngen={{ngen}} samplefreq={{samplefreq}} printfreq={{printfreq}} diagnfreq={{printfreq}} file={{output_prefix}};
+    mcmc;
+    sump burninfrac={{burnin_frac}};
+    sumt burninfrac={{burnin_frac}};
+end;

--- a/templates/process-golden-for-nni-exploration.sh
+++ b/templates/process-golden-for-nni-exploration.sh
@@ -33,6 +33,7 @@ rerooted1=ds{{ds_number}}.rerooted.nwk
 rerooted2=ds{{ds_number}}.credible.rerooted.nwk 
 rerooted3=ds{{ds_number}}.mb-trees.rerooted.nwk
 out1=ds{{ds_number}}.representations.csv 
+out1_extra=ds{{ds_number}}.topologies.nwk
 out2=ds{{ds_number}}.credible.representations.csv 
 out3=ds{{ds_number}}.mb-trees.representations.csv
 # To make sure taxon ordering is the same, all files have the same first tree.
@@ -49,12 +50,12 @@ then
   out4=ds{{ds_number}}.extra-trees.representations.csv
   head -n 1 $rerooted1 > rerooted4
   cat $rerooted4 >> rerooted4
-  reps_and_likelihoods ds{{ds_number}}.fasta $rerooted1 $out1 rerooted2 out2 rerooted3 out3 rerooted4 out4
+  reps_and_likelihoods ds{{ds_number}}.fasta $rerooted1 $out1 $out1_extra rerooted2 out2 rerooted3 out3 rerooted4 out4
   tail -n +2 out4 > $out4
   rm rerooted4
   rm out4
 else
-  reps_and_likelihoods ds{{ds_number}}.fasta $rerooted1 $out1 rerooted2 out2 rerooted3 out3
+  reps_and_likelihoods ds{{ds_number}}.fasta $rerooted1 $out1 $out1_extra rerooted2 out2 rerooted3 out3
 fi
 tail -n +2 out2 > $out2
 tail -n +2 out3 > $out3


### PR DESCRIPTION
A lot of scripts have minor changes to support switching to parsimony scores. For someone calling the scripts, it's a change to one line and is documented in the readme. The file wtch-nni-likelihood-walk.py has the major changes, with the old method load_trees refactored into smaller pieces.

There are no formal tests, but full runs (6 million trees) were done for parsimony and likelihood with and without extra trees.

Closes #9.